### PR TITLE
Compatibility with new laravel version 6.0

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -2,9 +2,8 @@
 
 namespace Bissolli\NovaPhoneField;
 
-use Illuminate\Support\Arr;
 use Laravel\Nova\Fields\Field;
-
+use Illuminate\Support\Arr;
 
 class PhoneNumber extends Field
 {

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -2,8 +2,9 @@
 
 namespace Bissolli\NovaPhoneField;
 
-use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Arr;
+use Laravel\Nova\Fields\Field;
+
 
 class PhoneNumber extends Field
 {

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -2,8 +2,8 @@
 
 namespace Bissolli\NovaPhoneField;
 
-use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Arr;
+use Laravel\Nova\Fields\Field;
 
 class PhoneNumber extends Field
 {

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -3,7 +3,7 @@
 namespace Bissolli\NovaPhoneField;
 
 use Laravel\Nova\Fields\Field;
-
+use Illuminate\Support\Arr;
 class PhoneNumber extends Field
 {
     /**
@@ -22,7 +22,7 @@ class PhoneNumber extends Field
     public function withCustomFormats(...$customFormats)
     {
         return $this->withMeta([
-            'customFormats' => array_flatten($customFormats),
+            'customFormats' => Arr::flatten($customFormats),
         ]);
     }
 
@@ -35,7 +35,7 @@ class PhoneNumber extends Field
     public function onlyCountries(...$countries)
     {
         return $this->withMeta([
-            'onlyCountries' => array_flatten($countries),
+            'onlyCountries' => Arr::flatten($countries),
         ]);
     }
 

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -4,6 +4,7 @@ namespace Bissolli\NovaPhoneField;
 
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Arr;
+
 class PhoneNumber extends Field
 {
     /**


### PR DESCRIPTION
In new versions of laravel nova there is no longer the array_flatten that was replaced by Arr :: flatten and now it is necessary to import the class use Illuminate \ Support \ Arr; for the project to work on laravel version 6.0 and other versions.